### PR TITLE
Fixed team switch form's checking for extra spaces in "name" field

### DIFF
--- a/app/controllers/team_switch_form_controller.rb
+++ b/app/controllers/team_switch_form_controller.rb
@@ -37,7 +37,7 @@ class TeamSwitchFormController < ApplicationController
 
   # Returns a dancer if name and a contact point (phone OR email) has been filled out properly
   def find_dancer(name, phone, email)
-    for dancer in Dancer.where("replace(lower(name), ' ', '') = ?",  name.downcase.delete(' '))
+    for dancer in Dancer.where("replace(lower(name), ' ', '') = ?", name.downcase.delete(" "))
       if phone == dancer.phone || email == dancer.email
         return dancer
       end

--- a/app/controllers/team_switch_form_controller.rb
+++ b/app/controllers/team_switch_form_controller.rb
@@ -37,7 +37,7 @@ class TeamSwitchFormController < ApplicationController
 
   # Returns a dancer if name and a contact point (phone OR email) has been filled out properly
   def find_dancer(name, phone, email)
-    for dancer in Dancer.where("lower(name) = ?", name.downcase)
+    for dancer in Dancer.where("replace(lower(name), ' ', '') = ?",  name.downcase.delete(' '))
       if phone == dancer.phone || email == dancer.email
         return dancer
       end


### PR DESCRIPTION
resolve issue #31 : fixed the whitespace checker for the teamswitch form so that the request goes through. However the name on the team switch request is whatever they put in the teamswitch form, which might be different from their name in the dancer database. not sure if that might affect anything