### PR TITLE
Team doesn't show in team switch form when full

### DIFF
--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -20,8 +20,12 @@ ActiveAdmin.register Team do
       :locked,
       :maximum_picks,
       :level,
+      :display,
+      :max_size,
       # Necessary in order to properly link users and teams
       user_ids: [],
+
+
     ].compact
   end
 
@@ -40,6 +44,8 @@ ActiveAdmin.register Team do
               ].join("<br>").html_safe
       f.input :locked
       f.input :maximum_picks
+      f.input :display
+      f.input :max_size
     end
     f.actions
   end
@@ -50,6 +56,8 @@ ActiveAdmin.register Team do
     column :level
     column :practice_time
     column :locked
+    column :display
+    column :max_size
     column :maximum_picks
     # Allows us to view the Users that are connected to the team
     column "User" do |team|
@@ -108,6 +116,9 @@ ActiveAdmin.register Team do
     team_id = params[:id]
     dancer_id = params[:dancer_id]
     drop_dancer_from_team(dancer_id, team_id)
+
+    display = team.dancers.length < max_size
+
   end
 
   controller do

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -112,8 +112,7 @@ class Team < ApplicationRecord
     # Actually add the dancers to this team
     dancers.push(*added)
 
-    #display = dancers.length < max_size
-    self.send("display=", dancers.length < max_size)
+    update(display: (dancers.length < max_size))
 
     return {
       added: added,
@@ -137,8 +136,7 @@ class Team < ApplicationRecord
     # Actually remove the dancers from this team
     dancers.delete(*removed)
 
-    #display = dancers.length < max_size
-    self.send("display=", dancers.length < max_size)
+    update(display: (dancers.length < max_size))
 
     return {
       removed: removed,

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -80,6 +80,10 @@ class Team < ApplicationRecord
   #   update(locked: !locked)
   # end
 
+  # def toggle_display
+  #   update(display: !display)
+  # end
+
   def dancers_with_added_at_added_reason
     dancers
       .joins(:dancers_teams)
@@ -108,6 +112,9 @@ class Team < ApplicationRecord
     # Actually add the dancers to this team
     dancers.push(*added)
 
+    #display = dancers.length < max_size
+    self.send("display=", dancers.length < max_size)
+
     return {
       added: added,
       already_in_this_team: already_in_this_team,
@@ -129,6 +136,9 @@ class Team < ApplicationRecord
 
     # Actually remove the dancers from this team
     dancers.delete(*removed)
+
+    #display = dancers.length < max_size
+    self.send("display=", dancers.length < max_size)
 
     return {
       removed: removed,

--- a/app/views/team_switch_form/index.html.erb
+++ b/app/views/team_switch_form/index.html.erb
@@ -42,7 +42,7 @@
         :id,
         :name
       ) do |option| %>
-    <% next if option.object.practice_time.blank? || option.object.practice_time[0] == " " %>
+    <% next if !option.object.display || option.object.practice_time.blank? || option.object.practice_time[0] == " " %>
     <div><label>
       <%= option.check_box(class: "availability-checkbox availability-checkbox-project") %>
       <span class="availability-display" style="display: none">

--- a/app/views/team_switch_form/index.html.erb
+++ b/app/views/team_switch_form/index.html.erb
@@ -68,7 +68,7 @@
         :id,
         :name
       ) do |option| %>
-    <% next if option.object.practice_time.blank? || option.object.practice_time[0] == " " %>
+    <% next if !option.object.display || option.object.practice_time.blank? ||      option.object.practice_time[0] == " " %> <!--change this so there's a boolean-->
     <div><label>
       <%= option.check_box(class: "availability-checkbox availability-checkbox-training") %>
       <span class="availability-display" style="display: none">

--- a/db/migrate/20181006185211_set_display_max_size_in_team.rb
+++ b/db/migrate/20181006185211_set_display_max_size_in_team.rb
@@ -1,0 +1,10 @@
+class SetDisplayMaxSizeInTeam < ActiveRecord::Migration[5.1]
+  def self.up
+    add_column :teams, :display, :boolean, :default => true
+    add_column :teams, :max_size, :integer, :default => 2
+  end
+
+  def self.down
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180629155626) do
+ActiveRecord::Schema.define(version: 20181006185211) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -85,6 +85,8 @@ ActiveRecord::Schema.define(version: 20180629155626) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "display", default: true
+    t.integer "max_size", default: 2
     t.index ["user_id"], name: "index_teams_on_user_id"
   end
 


### PR DESCRIPTION
Fixes #27

Checks if the number of dancers on the team is greater than the maximum size every time a dancer is added or dropped. If it is greater, then that team won't show up on the team switch form. Once the number of dancers on a team becomes less than the maximum size, the team appears back on the form.