### PR TITLE
Non-admin users can no longer access team switch request page and users page

### DIFF
--- a/app/admin/team_switch_requests.rb
+++ b/app/admin/team_switch_requests.rb
@@ -58,10 +58,8 @@ ActiveAdmin.register TeamSwitchRequest do
     process_team_switch_request_into_team(team_switch_request_id, team_id)
   end
 
-
   controller do
-
-    #checks if user can view the team switch requests page
+    # checks if user can view the team switch requests page
     def role_check
       if !current_user.can_view_team_switch?
         redirect_to :back, alert: "You can't view the team switch requests page!!! >:( uwu"
@@ -156,9 +154,6 @@ ActiveAdmin.register TeamSwitchRequest do
   end
 
   index do
-    #if !current_user.can_view_team_switch?
-   #   redirect_to :back, alert: "Not allowed to view this"
-    #end
     selectable_column
     # https://github.com/activeadmin/activeadmin/issues/1995#issuecomment-15846811
     TeamSwitchRequest.content_columns.each { |col| column col.name.to_sym }

--- a/app/admin/team_switch_requests.rb
+++ b/app/admin/team_switch_requests.rb
@@ -62,7 +62,7 @@ ActiveAdmin.register TeamSwitchRequest do
     # checks if user can view the team switch requests page
     def role_check
       if !current_user.can_view_team_switch?
-        redirect_to :back, alert: "You can't view the team switch requests page!!! >:( uwu"
+        redirect_to "/admin", alert: "You can't view the team switch requests page!!! >:( uwu"
         return
       end
     end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register User do
-  scope_to :current_user, association_method: :teams # , unless: proc { current_user.can_view_users? }
+  before_action :role_check
 
   permit_params(
     :username,
@@ -7,6 +7,16 @@ ActiveAdmin.register User do
     :password_confirmation,
     team_ids: [], # Necessary in order to properly link users and teams
   )
+
+  controller do
+    # checks if user can view the team switch requests page
+    def role_check
+      if !current_user.can_view_users?
+        redirect_to "/admin", alert: "You can't view the users page!!! >:( uwu"
+        return
+      end
+    end
+  end
 
   index do
     selectable_column

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register User do
-  scope_to :current_user, unless: proc { current_user.can_view_users? }
+  scope_to :current_user, association_method: :teams # , unless: proc { current_user.can_view_users? }
+
   permit_params(
     :username,
     :password,
@@ -21,7 +22,6 @@ ActiveAdmin.register User do
     end
     column :role
     actions
-
   end
 
   filter :username

--- a/test/models/dancer_test.rb
+++ b/test/models/dancer_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 class DancerTest < ActiveSupport::TestCase
-
   test "dancers added" do
     assert_equal 2, Dancer.count
   end
@@ -43,16 +42,16 @@ class DancerTest < ActiveSupport::TestCase
   end
 
   test "Patricia's phone number" do
-    assert_equal '510-505-4813', dancers(:patricia).phone
+    assert_equal "510-505-4813", dancers(:patricia).phone
   end
 
- test "Patricia's email" do
-    email = 'patriciayu7@berkeley.edu'
+  test "Patricia's email" do
+    email = "patriciayu7@berkeley.edu"
     assert_equal email, dancers(:patricia).email
   end
 
   test "Patricia's experience" do
-    #should fail
-    assert_equal 'some', dancers(:patricia).dance_experience
+    # should fail
+    assert_equal "some", dancers(:patricia).dance_experience
   end
 end


### PR DESCRIPTION
Adjusted permissions for viewing team switch request (TSR) and users pages. Got rid of the scope_to method, instead changing to using a before_action filter. When one of these pages is opened, first runs "before_action :role_check". This runs the "role_check" method in the "controller do" suite. This method checks if the current user has permission to view the page (based on whether they are an admin or a director.) 

If user does not have permission, redirects user back to the dashboard page instead of opening the page. Then gives an error message at the top of the page stating the user cannot view the page. 

Does not include hiding the buttons at the top of the page.

Child links are also blocked from view (i.e users/1)