### PR TITLE
Fixed weird scroll for audition form

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -139,6 +139,5 @@ form p {
 }
 
 html, body {
-    height: 100%;
     overflow: auto;
 }


### PR DESCRIPTION
The bug was that two scroll bars would show up in the audition form which made scrolling very buggy because it kept switching between the two scroll bars.

Now the audition form should have just one scroll bar