### PR TITLE
Teamswitch form drop text changes

### DIFF
--- a/app/views/team_switch_form/index.html.erb
+++ b/app/views/team_switch_form/index.html.erb
@@ -122,7 +122,7 @@
         :name
       ) do |option| %>
         <div><label>
-          <%= option.check_box(class: "availability-checkbox availability-checkbox-drop") %> Yes, I would like to withdraw from AFX Spring 2020 Project/Training. I acknowledge that my decision is final and that once I submit the form, I will no longer be able to join any team practice or perform in any AFX set this semester (NO EXCEPTIONS). If I violate these conditions and do not pay AFX dues, I will be charged at any time.
+          <%= option.check_box(class: "availability-checkbox availability-checkbox-drop") %> Yes, I would like to withdraw from AFX Fall 2021 Project/Training. I acknowledge that my decision is final and that once I submit the form, I will no longer be able to join any team practice or perform in any AFX set this semester (NO EXCEPTIONS). If I violate these conditions and do not pay AFX dues, I will be charged at any time.
         </label></div>
       <% end %>
 


### PR DESCRIPTION
change html text of teamswitch form so that the "drop" option has text for Fall 2021 instead of Spring 2020