### PR TITLE
Change TeamSwitch form to allow submitting with 1 training team time

### DIFF
--- a/app/views/team_switch_form/index.html.erb
+++ b/app/views/team_switch_form/index.html.erb
@@ -174,8 +174,9 @@
 
               // If someone on a project team puts down a project team time and a training team time,
               // then that's okay.
-              if (nchecked.project == 0 && nchecked.training == 1)
-                  return false;
+              // Fa21: Commented below code out because there are only 2 training teams so we want to allow dancers to request only 1 team
+              // if (nchecked.project == 0 && nchecked.training == 1)
+              //     return false;
 
               return true;
           }


### PR DESCRIPTION
In the past we had a check that wouldn't display the submit button unless 2 training team times were selected. Since this semester we have only 2 training teams, this code portion is commented out so that the submit button still shows even with 1 training team time selected in the team switch form