### PR TITLE
Only processed team switch requests are displayed in teams view

### DIFF
--- a/app/models/team_switch_request.rb
+++ b/app/models/team_switch_request.rb
@@ -23,6 +23,6 @@ class TeamSwitchRequest < ApplicationRecord
   # If the new team isn't nil then that means the request has been processed
   # Return relevant team switch requests, either the dancer just joined or just left team_id
   def self.get_processed_team_switch_requests(team_id)
-    TeamSwitchRequest.where.not(new_team_id: nil).where("new_team_id = '#{team_id}' or old_team_id = '#{team_id}'")
+    TeamSwitchRequest.where("new_team_id is not null and (new_team_id = ? or old_team_id = ?)", team_id, team_id)
   end
 end

--- a/app/models/team_switch_request.rb
+++ b/app/models/team_switch_request.rb
@@ -23,6 +23,6 @@ class TeamSwitchRequest < ApplicationRecord
   # If the new team isn't nil then that means the request has been processed
   # Return relevant team switch requests, either the dancer just joined or just left team_id
   def self.get_processed_team_switch_requests(team_id)
-    TeamSwitchRequest.where("new_team_id = '#{team_id}' or old_team_id = '#{team_id}'")
+    TeamSwitchRequest.where.not(new_team_id: nil).where("new_team_id = '#{team_id}' or old_team_id = '#{team_id}'")
   end
 end


### PR DESCRIPTION
Unprocessed team switch requests were also showing up in the teams view. This change simply adds another query that the new_team_id must not be nil in order for it to be displayed in teams view.